### PR TITLE
Konsequente Einrückung durch Instanzvariable

### DIFF
--- a/packages/OmegaPrint-Core.package/OPPrinter.class/instance/MethodDeclaration.with.and.and..st
+++ b/packages/OmegaPrint-Core.package/OPPrinter.class/instance/MethodDeclaration.with.and.and..st
@@ -1,9 +1,9 @@
 actions
-MethodDeclaration: aNode with: header and: pragmas and: code
+MethodDeclaration: aNode with: aMethodHeader and: x and: executableCode
 
-	| comment |
-	comment := self commentBetween: header and: code.
-	comment isEmpty ifFalse: [comment := String tab , comment].
+	| comment header |
+	header := self defaultExpression: aMethodHeader.
+	self increaseIndentation.
+	comment := self commentBetween: aMethodHeader and: executableCode.
 	
-	^ (self defaultExpression: header) , String cr , comment , String cr , String tab ,
-		(self defaultExpression: code)
+	^ header , comment , self newline , (self defaultExpression: executableCode)

--- a/packages/OmegaPrint-Core.package/OPPrinter.class/instance/MethodDeclaration.with.and.and..st
+++ b/packages/OmegaPrint-Core.package/OPPrinter.class/instance/MethodDeclaration.with.and.and..st
@@ -1,5 +1,5 @@
 actions
-MethodDeclaration: aNode with: aMethodHeader and: x and: executableCode
+MethodDeclaration: aNode with: aMethodHeader and: pragmas and: executableCode
 
 	| comment header |
 	header := self defaultExpression: aMethodHeader.

--- a/packages/OmegaPrint-Core.package/OPPrinter.class/instance/Statements.withManyStatements.withLiterals..st
+++ b/packages/OmegaPrint-Core.package/OPPrinter.class/instance/Statements.withManyStatements.withLiterals..st
@@ -3,4 +3,4 @@ Statements: aNode withManyStatements: statements withLiterals: literals
 	
 	^ statements children 
 		inject: ''
-		into: [:code :node | code , (self value: node) , '.' , Character cr , String tab]
+		into: [:code :node | code , (self value: node) , '.' , self newline ]

--- a/packages/OmegaPrint-Core.package/OPPrinter.class/instance/commentBetween.and..st
+++ b/packages/OmegaPrint-Core.package/OPPrinter.class/instance/commentBetween.and..st
@@ -1,4 +1,11 @@
-actions
+comments
 commentBetween: aNode and: anotherNode
 
-	^ (aNode interval stream contents copyFrom: aNode interval end + 1 to: anotherNode interval start - 1) withBlanksTrimmed.
+	| comment |
+	comment := aNode interval stream contents
+		copyFrom: aNode interval end + 1
+		to: anotherNode interval start - 1.
+	comment := comment withBlanksTrimmed.
+	comment isEmpty 
+		ifTrue: [ ^ String cr ]
+		ifFalse: [ ^ self newline , comment ]

--- a/packages/OmegaPrint-Core.package/OPPrinter.class/instance/decreaseIndentation.st
+++ b/packages/OmegaPrint-Core.package/OPPrinter.class/instance/decreaseIndentation.st
@@ -1,0 +1,4 @@
+indentation
+decreaseIndentation
+
+	self indentation: self indentation - 1

--- a/packages/OmegaPrint-Core.package/OPPrinter.class/instance/increaseIndentation.st
+++ b/packages/OmegaPrint-Core.package/OPPrinter.class/instance/increaseIndentation.st
@@ -1,0 +1,4 @@
+indentation
+increaseIndentation
+
+	self indentation: self indentation + 1

--- a/packages/OmegaPrint-Core.package/OPPrinter.class/instance/indentation..st
+++ b/packages/OmegaPrint-Core.package/OPPrinter.class/instance/indentation..st
@@ -1,0 +1,4 @@
+accessing
+indentation: aNumber
+
+	indentation := aNumber

--- a/packages/OmegaPrint-Core.package/OPPrinter.class/instance/indentation.st
+++ b/packages/OmegaPrint-Core.package/OPPrinter.class/instance/indentation.st
@@ -1,0 +1,4 @@
+accessing
+indentation
+
+	^ indentation

--- a/packages/OmegaPrint-Core.package/OPPrinter.class/instance/initialize.st
+++ b/packages/OmegaPrint-Core.package/OPPrinter.class/instance/initialize.st
@@ -1,0 +1,5 @@
+initialize-release
+initialize
+
+	super initialize.
+	self indentation: 0

--- a/packages/OmegaPrint-Core.package/OPPrinter.class/instance/newline.st
+++ b/packages/OmegaPrint-Core.package/OPPrinter.class/instance/newline.st
@@ -1,0 +1,7 @@
+indentation
+newline
+
+	| result |
+	result := String cr.
+	self indentation timesRepeat: [ result := result , String tab ].
+	^ result

--- a/packages/OmegaPrint-Core.package/OPPrinter.class/methodProperties.json
+++ b/packages/OmegaPrint-Core.package/OPPrinter.class/methodProperties.json
@@ -4,7 +4,7 @@
 	"instance" : {
 		"FinalStatement:with:and:and:" : "fau 5/25/2020 21:12",
 		"LocalVariableDeclarationList:with:and:and:" : "fau 5/26/2020 10:10",
-		"MethodDeclaration:with:and:and:" : "fau 5/26/2020 09:55",
+		"MethodDeclaration:with:and:and:" : "fau 5/27/2020 20:27",
 		"Statements:withManyStatements:withLiterals:" : "fau 5/26/2020 09:56",
 		"commentBetween:and:" : "fau 5/26/2020 09:50",
 		"decreaseIndentation" : "fau 5/26/2020 09:46",

--- a/packages/OmegaPrint-Core.package/OPPrinter.class/methodProperties.json
+++ b/packages/OmegaPrint-Core.package/OPPrinter.class/methodProperties.json
@@ -4,6 +4,12 @@
 	"instance" : {
 		"FinalStatement:with:and:and:" : "fau 5/25/2020 21:12",
 		"LocalVariableDeclarationList:with:and:and:" : "fau 5/26/2020 10:10",
-		"MethodDeclaration:with:and:and:" : "fau 5/21/2020 20:55",
-		"Statements:withManyStatements:withLiterals:" : "fau 5/21/2020 20:41",
-		"commentBetween:and:" : "fau 5/21/2020 20:54" } }
+		"MethodDeclaration:with:and:and:" : "fau 5/26/2020 09:55",
+		"Statements:withManyStatements:withLiterals:" : "fau 5/26/2020 09:56",
+		"commentBetween:and:" : "fau 5/26/2020 09:50",
+		"decreaseIndentation" : "fau 5/26/2020 09:46",
+		"increaseIndentation" : "fau 5/26/2020 09:46",
+		"indentation" : "fau 5/26/2020 10:39",
+		"indentation:" : "fau 5/26/2020 10:39",
+		"initialize" : "fau 5/26/2020 10:37",
+		"newline" : "fau 5/26/2020 09:47" } }

--- a/packages/OmegaPrint-Core.package/OPPrinter.class/properties.json
+++ b/packages/OmegaPrint-Core.package/OPPrinter.class/properties.json
@@ -6,7 +6,7 @@
 		 ],
 	"commentStamp" : "",
 	"instvars" : [
-		 ],
+		"indentation" ],
 	"name" : "OPPrinter",
 	"pools" : [
 		 ],


### PR DESCRIPTION
Closes #7 

Die aktuelle Einrückung wird in einer Instanzvariable gespeichert. Bei jedem Zeilenumbruch wird dann direkt um die gespeicherte Einrückung eingerückt. Wann ein Zeilenumbruch gemacht wird sollte den Knoten selbst überlassen werden und ist demnach nicht Teil dieser PR.