### PR TITLE
ExecutableCode besser testen

### DIFF
--- a/packages/OmegaPrint-Core.package/OPPrinter.class/instance/ExecutableCode.with.and.and..st
+++ b/packages/OmegaPrint-Core.package/OPPrinter.class/instance/ExecutableCode.with.and.and..st
@@ -7,4 +7,4 @@ ExecutableCode: aNode with: aLocalVariableDeclarationList and: pragmas and: more
 	codeResult := self value: moreExecutableCode.
 	localVariablesResult ifNotEmpty: [ localVariablesResult := localVariablesResult , self newline ].
 	pragmasResult ifNotEmpty: [ pragmasResult := pragmasResult , self newline ].
-	^ localVariablesResult , pragmasResult , codeResult
+	^ (localVariablesResult , pragmasResult , codeResult) withBlanksTrimmed

--- a/packages/OmegaPrint-Core.package/OPPrinter.class/methodProperties.json
+++ b/packages/OmegaPrint-Core.package/OPPrinter.class/methodProperties.json
@@ -11,7 +11,7 @@
 		"BlockLiteralSpecialEmpty:with:and:and:" : "TA 6/14/2020 20:33",
 		"ByteArrayLiteral:with:and:and:" : "fau 7/12/2020 21:07",
 		"CascadedMessages:with:and:and:" : "PK 7/5/2020 18:45",
-		"ExecutableCode:with:and:and:" : "TA 7/16/2020 16:14",
+		"ExecutableCode:with:and:and:" : "fau 7/24/2020 10:11",
 		"ExpressionBinaryCascade:with:and:" : "TA 7/10/2020 10:50",
 		"ExpressionOperandCascade:with:and:" : "TA 6/8/2020 19:10",
 		"ExpressionUnaryCascade:with:and:" : "TA 7/10/2020 10:32",

--- a/packages/OmegaPrint-Tests.package/TestExecutableCode.class/instance/testWithVariablesWithPragmasWithoutCode.st
+++ b/packages/OmegaPrint-Tests.package/TestExecutableCode.class/instance/testWithVariablesWithPragmasWithoutCode.st
@@ -1,0 +1,6 @@
+base
+testWithVariablesWithPragmasWithoutCode
+
+	self
+		prettify: '|variable|<pragma>'
+		shouldEqual: '| variable |' , String cr , '<pragma>'

--- a/packages/OmegaPrint-Tests.package/TestExecutableCode.class/instance/testWithVariablesWithoutPragmasWithoutCode.st
+++ b/packages/OmegaPrint-Tests.package/TestExecutableCode.class/instance/testWithVariablesWithoutPragmasWithoutCode.st
@@ -1,0 +1,6 @@
+base
+testWithVariablesWithoutPragmasWithoutCode
+
+	self
+		prettify: '|variable|'
+		shouldEqual: '| variable |'

--- a/packages/OmegaPrint-Tests.package/TestExecutableCode.class/instance/testWithoutVariablesWithPragmasWithoutCode.st
+++ b/packages/OmegaPrint-Tests.package/TestExecutableCode.class/instance/testWithoutVariablesWithPragmasWithoutCode.st
@@ -1,0 +1,6 @@
+base
+testWithoutVariablesWithPragmasWithoutCode
+
+	self
+		prettify: '<pragma>'
+		shouldEqual: '<pragma>'

--- a/packages/OmegaPrint-Tests.package/TestExecutableCode.class/instance/testWithoutVariablesWithoutPragmasWithoutCode.st
+++ b/packages/OmegaPrint-Tests.package/TestExecutableCode.class/instance/testWithoutVariablesWithoutPragmasWithoutCode.st
@@ -1,0 +1,6 @@
+base
+testWithoutVariablesWithoutPragmasWithoutCode
+
+	self
+		prettify: ''
+		shouldEqual: ''

--- a/packages/OmegaPrint-Tests.package/TestExecutableCode.class/methodProperties.json
+++ b/packages/OmegaPrint-Tests.package/TestExecutableCode.class/methodProperties.json
@@ -4,6 +4,10 @@
 	"instance" : {
 		"startSymbol" : "PS 7/5/2020 17:52",
 		"testWithVariablesWithPragmasWithCode" : "TA 7/16/2020 16:09",
+		"testWithVariablesWithPragmasWithoutCode" : "fau 7/24/2020 10:09",
 		"testWithVariablesWithoutPragmasWithCode" : "fau 7/10/2020 10:29",
+		"testWithVariablesWithoutPragmasWithoutCode" : "fau 7/24/2020 10:10",
 		"testWithoutVariablesWithPragmasWithCode" : "TA 7/16/2020 16:09",
-		"testWithoutVariablesWithoutPragmasWithCode" : "fau 7/10/2020 10:29" } }
+		"testWithoutVariablesWithPragmasWithoutCode" : "fau 7/24/2020 10:10",
+		"testWithoutVariablesWithoutPragmasWithCode" : "fau 7/10/2020 10:29",
+		"testWithoutVariablesWithoutPragmasWithoutCode" : "fau 7/24/2020 10:10" } }


### PR DESCRIPTION
Durch die Tests ist aufgefallen, dass wir zu viele Newlines setzen, das haben wir korrigiert.
Closes #70 