### PR TITLE
Installationsanleitung korrigieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ dev: ![CI](https://github.com/hpi-swa-teaching/OhmPrettyPrint/workflows/CI/badge
 master: ![CI](https://github.com/hpi-swa-teaching/OhmPrettyPrint/workflows/CI/badge.svg?branch=master)
 
 ## How to install
-```
+```smalltalk
 Metacello new
 	baseline: 'OhmPrettyPrint';
-	repository: 'github://hpi-swa-teaching/OhmPrettyPrint';
-	load.
+	repository: 'github://HPI-SWA-Teaching/OhmPrettyPrint:dev/packages';
+	load
 ```


### PR DESCRIPTION
Wie Ben in #107 geschrieben hat, funktioniert unsere Installationsanleitung nicht. Mit diesem Fix liegt eine Installationsanleitung fuer den dev auf dem dev selbst. Wir sollten das demnaechst mal eine PR auf den master aufmachen (und dann den master in der Installationsanleitung nehmen?), damit man das auch auf der Hauptseite unseres Repos sofort sieht.

Closes #107 