### PR TITLE
KeywordMessages (und andere Messages)

### DIFF
--- a/packages/OmegaPrint-Core.package/OPSourceRewriter.class/instance/BinaryMessageSend.with.and..st
+++ b/packages/OmegaPrint-Core.package/OPSourceRewriter.class/instance/BinaryMessageSend.with.and..st
@@ -1,6 +1,0 @@
-actions
-BinaryMessageSend: aNode with: aBinaryMessageReceiver and: aBinaryMessage
-
-	^ self
-		join: { aBinaryMessageReceiver . aBinaryMessage }
-		separatedBy: ' '

--- a/packages/OmegaPrint-Core.package/OPSourceRewriter.class/instance/KeywordMessage.with..st
+++ b/packages/OmegaPrint-Core.package/OPSourceRewriter.class/instance/KeywordMessage.with..st
@@ -1,0 +1,9 @@
+actions
+KeywordMessage: aNode with: keywordMessageSegments
+
+	| result |
+	result := self
+		keywordMessageWith: String empty
+		and: keywordMessageSegments.
+	keywordMessageSegments numberOfChildren > 1 ifTrue: [ result := String tab , result ].
+	^ result

--- a/packages/OmegaPrint-Core.package/OPSourceRewriter.class/instance/KeywordMessageSend.with.and..st
+++ b/packages/OmegaPrint-Core.package/OPSourceRewriter.class/instance/KeywordMessageSend.with.and..st
@@ -1,13 +1,6 @@
 actions
 KeywordMessageSend: aNode with: aKeywordMessageReceiver and: keywordMessageSegments
 
-	| separator result |
-	self increaseIndentation.
-	keywordMessageSegments numberOfChildren <= 1
-		ifTrue: [ separator := String space ]
-		ifFalse: [ separator := self newline ].
-	self decreaseIndentation.
-	result := self
-		join: { aKeywordMessageReceiver } , keywordMessageSegments children
-		separatedBy: separator.
-	^ result
+	^ self
+		keywordMessageWith: aKeywordMessageReceiver
+		and: keywordMessageSegments

--- a/packages/OmegaPrint-Core.package/OPSourceRewriter.class/instance/keywordMessageWith.and..st
+++ b/packages/OmegaPrint-Core.package/OPSourceRewriter.class/instance/keywordMessageWith.and..st
@@ -1,0 +1,14 @@
+helpers
+keywordMessageWith: aReceiver and: segments
+
+	| result |
+	segments numberOfChildren <= 1
+		ifTrue: [ result := self
+			join: { aReceiver } , segments children
+			separatedBy: String space ]
+		ifFalse: [ self increaseIndentation.
+			result := self
+				join: { aReceiver } , segments children
+				separatedBy: self newline.
+			self decreaseIndentation ].
+	^ result

--- a/packages/OmegaPrint-Core.package/OPSourceRewriter.class/methodProperties.json
+++ b/packages/OmegaPrint-Core.package/OPSourceRewriter.class/methodProperties.json
@@ -2,7 +2,6 @@
 	"class" : {
 		 },
 	"instance" : {
-		"BinaryMessageSend:with:and:" : "TA 8/4/2020 13:12",
 		"BlockLiteralNormal:with:and:and:and:" : "fau 8/5/2020 13:58",
 		"ByteArrayLiteral:with:and:and:" : "fau 8/5/2020 09:49",
 		"CascadedMessages:with:and:and:" : "fau 8/5/2020 13:59",
@@ -11,7 +10,8 @@
 		"ExpressionOperandCascade:with:and:" : "TA 7/29/2020 15:00",
 		"ExpressionUnaryCascade:with:and:" : "TA 7/29/2020 15:00",
 		"FinalStatement:with:and:and:" : "TA 8/4/2020 13:13",
-		"KeywordMessageSend:with:and:" : "TA 8/6/2020 08:07",
+		"KeywordMessage:with:" : "fau 8/6/2020 14:47",
+		"KeywordMessageSend:with:and:" : "fau 8/6/2020 14:39",
 		"LiteralArrayLiteral:with:and:and:" : "PK 8/2/2020 19:49",
 		"LiteralArrayLiteralInLiteralArray:with:and:and:and:" : "PK 8/2/2020 19:49",
 		"MethodDeclaration:with:and:and:" : "fau 8/5/2020 22:06",
@@ -34,6 +34,7 @@
 		"indentation:" : "fau 8/5/2020 21:42",
 		"initialize" : "fau 8/5/2020 14:18",
 		"join:separatedBy:" : "fau 8/4/2020 22:11",
+		"keywordMessageWith:and:" : "fau 8/6/2020 14:37",
 		"literalArrayWith:" : "fau 8/5/2020 09:49",
 		"newline" : "fau 8/5/2020 21:38",
 		"spaceInBlockWith:and:and:" : "fau 8/5/2020 14:00",

--- a/packages/OmegaPrint-Tests.package/TestExpression.class/instance/testMultipleSegmentsInCascade.st
+++ b/packages/OmegaPrint-Tests.package/TestExpression.class/instance/testMultipleSegmentsInCascade.st
@@ -1,0 +1,7 @@
+special cases
+testMultipleSegmentsInCascade
+
+	self
+		prettify: 'receiver keyword1:arg1 keyword2:arg2;message'
+		shouldEqual: 'receiver' , String cr , String tab , String tab , 'keyword1: arg1' ,
+			String cr , String tab , String tab , 'keyword2: arg2;' , String cr , String tab , 'message'

--- a/packages/OmegaPrint-Tests.package/TestExpression.class/methodProperties.json
+++ b/packages/OmegaPrint-Tests.package/TestExpression.class/methodProperties.json
@@ -3,6 +3,7 @@
 		 },
 	"instance" : {
 		"startSymbol" : "TA 7/10/2020 10:50",
+		"testMultipleSegmentsInCascade" : "fau 8/6/2020 14:57",
 		"testWithBinaryMessageSendWithCascadedMessages" : "PK 7/11/2020 14:55",
 		"testWithOperandWithCascadedMessages" : "PK 7/11/2020 14:53",
 		"testWithUnaryMessageSendWithCascadedMessages" : "PK 7/11/2020 14:53" } }

--- a/packages/OmegaPrint-Tests.package/TestKeywordMessage.class/instance/startSymbol.st
+++ b/packages/OmegaPrint-Tests.package/TestKeywordMessage.class/instance/startSymbol.st
@@ -1,0 +1,4 @@
+constants
+startSymbol
+
+	^ #KeywordMessage

--- a/packages/OmegaPrint-Tests.package/TestKeywordMessage.class/instance/testWithMultipleSegments.st
+++ b/packages/OmegaPrint-Tests.package/TestKeywordMessage.class/instance/testWithMultipleSegments.st
@@ -1,0 +1,6 @@
+base
+testWithMultipleSegments
+
+	self
+		prettify: 'keyword1:arg1 keyword2:arg2'
+		shouldEqual: String tab , 'keyword1: arg1' , String cr , String tab , 'keyword2: arg2'

--- a/packages/OmegaPrint-Tests.package/TestKeywordMessage.class/instance/testWithSingleSegment.st
+++ b/packages/OmegaPrint-Tests.package/TestKeywordMessage.class/instance/testWithSingleSegment.st
@@ -1,0 +1,6 @@
+base
+testWithSingleSegment
+
+	self
+		prettify: 'keyword:arg'
+		shouldEqual: 'keyword: arg'

--- a/packages/OmegaPrint-Tests.package/TestKeywordMessage.class/methodProperties.json
+++ b/packages/OmegaPrint-Tests.package/TestKeywordMessage.class/methodProperties.json
@@ -1,0 +1,7 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"startSymbol" : "fau 8/6/2020 13:58",
+		"testWithMultipleSegments" : "fau 8/6/2020 14:47",
+		"testWithSingleSegment" : "fau 8/6/2020 14:00" } }

--- a/packages/OmegaPrint-Tests.package/TestKeywordMessage.class/properties.json
+++ b/packages/OmegaPrint-Tests.package/TestKeywordMessage.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"category" : "OmegaPrint-Tests",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		 ],
+	"name" : "TestKeywordMessage",
+	"pools" : [
+		 ],
+	"super" : "OPTestEvaluator",
+	"type" : "normal" }

--- a/packages/OmegaPrint-Tests.package/TestKeywordMessageSend.class/instance/testMultipleSegmentsInArgument.st
+++ b/packages/OmegaPrint-Tests.package/TestKeywordMessageSend.class/instance/testMultipleSegmentsInArgument.st
@@ -1,0 +1,7 @@
+special cases
+testMultipleSegmentsInArgument
+
+	self
+		prettify: 'receiver1 keyword1:(receiver2 keyword3:arg3 keyword4:arg4)keyword2:arg2'
+		shouldEqual: 'receiver1' , String cr , String tab , 'keyword1: (receiver2' , String cr , String tab , String tab ,
+			'keyword3: arg3' , String cr , String tab , String tab , 'keyword4: arg4)' , String cr , String tab , 'keyword2: arg2'

--- a/packages/OmegaPrint-Tests.package/TestKeywordMessageSend.class/instance/testWithReceiverWithSingleSegmentWithComplexArgument.st
+++ b/packages/OmegaPrint-Tests.package/TestKeywordMessageSend.class/instance/testWithReceiverWithSingleSegmentWithComplexArgument.st
@@ -1,0 +1,6 @@
+special cases
+testWithReceiverWithSingleSegmentWithComplexArgument
+
+	self
+		prettify: 'receiver1 keyword1:(receiver2 keyword2:arg1 keyword3:arg2)'
+		shouldEqual: 'receiver1 keyword1: (receiver2' , String cr , String tab , 'keyword2: arg1' , String cr , String tab , 'keyword3: arg2)'

--- a/packages/OmegaPrint-Tests.package/TestKeywordMessageSend.class/methodProperties.json
+++ b/packages/OmegaPrint-Tests.package/TestKeywordMessageSend.class/methodProperties.json
@@ -3,6 +3,8 @@
 		 },
 	"instance" : {
 		"startSymbol" : "PS 7/5/2020 18:04",
+		"testMultipleSegmentsInArgument" : "fau 8/6/2020 15:03",
 		"testWithReceiverWithMultipleSegments" : "fau 7/10/2020 12:39",
 		"testWithReceiverWithSingleSegment" : "fau 7/10/2020 12:39",
+		"testWithReceiverWithSingleSegmentWithComplexArgument" : "fau 8/6/2020 14:15",
 		"testWithReceiverWithoutSegment" : "fau 7/10/2020 10:34" } }


### PR DESCRIPTION
## Diese PR macht folgendes:
- BinaryMessageSend wird geloescht, das wird von unserer defaultExpression abgedeckt (#145)
- Implementation von Methode und Tests fuer KeywordMessage (#143)
- Ueberarbeitung von KeywordMessageSends um #147 zu fixen
- spezielle Tests hinzufuegen, die das in #148 beschriebene Verhalten als gewollt ansehen und testen

### Zum letzten Punkt zwei Beispiele, wieso ich das Verhalten gut finde:
---
```smalltalk
 'receiver
        keyword1: arg1
        keyword2: arg2;
    message'
```
ist deutlich leichter zu lesen als
```smalltalk
 'receiver
    keyword1: arg1
    keyword2: arg2;
    message'
```
---
```smalltalk
 '[ receiver
        keyword1: arg1
        keyword2: arg2.
    statement ]'
```
ist deutlich leichter zu lesen als
```smalltalk
 '[ receiver
    keyword1: arg1
    keyword2: arg2.
    statement ]'
```
---
Man erkennt da in den beiden Beispielen meiner Meinung nach viel besser, was zur KeywordMessage gehoert und was das naechste Statement / die naechste MessageChain ist (ausserdem ist es auch im Code deutlich leichter umzusetzen).

Closes #145 
Closes #143 
Closes #147 
Closes #148 